### PR TITLE
Update DynamoClient.cs

### DIFF
--- a/Rook.Framework.DynamoDb/Data/DynamoClient.cs
+++ b/Rook.Framework.DynamoDb/Data/DynamoClient.cs
@@ -31,10 +31,7 @@ namespace Rook.Framework.DynamoDb.Data
             else
             {
                 Logger.Info("remote");
-                conf.RegionEndpoint = RegionEndpoint.EUWest1;
-                _dynamoClient = new AmazonDynamoDBClient(
-                    _configurationManager.Get<string>("AWSAccessKey"),
-                    _configurationManager.Get<string>("AWSSecretKey"),conf);
+                _dynamoClient = new AmazonDynamoDBClient();
             }
 
             var environment = configurationManager.Get<string>("ENVIRONMENT");


### PR DESCRIPTION
No longer explicitly specify credentials and region. This means the default .NET SDK resolution logic will be used to determine the credentials and region used (see _What You Need to Know_ at https://aws.amazon.com/blogs/developer/aws-sdk-dot-net-credential-profiles/) 